### PR TITLE
compiles and links with the right libraries for choosen architecture

### DIFF
--- a/mono/config.py
+++ b/mono/config.py
@@ -11,8 +11,12 @@ def configure(env):
     env.use_ptrcall = True
 
     if env['platform'] == 'windows':
-        env.Append(LIBPATH = 'C:\\Program Files\\Mono\\lib\\')
-        env.Append(CPPPATH = 'C:\\Program Files\\Mono\\include\\mono-2.0\\')
+        if env['bits'] == '64':
+            env.Append(LIBPATH = 'C:\\Program Files\\Mono\\lib\\')
+            env.Append(CPPPATH = 'C:\\Program Files\\Mono\\include\\mono-2.0\\')
+        else:
+            env.Append(LIBPATH = 'C:\\Program Files (x86)\\Mono\\lib\\')
+            env.Append(CPPPATH = 'C:\\Program Files (x86)\\Mono\\include\\mono-2.0\\')
 
         env.Append(LINKFLAGS = [ 'monosgen-2.0.lib' ])
     else:


### PR DESCRIPTION
While it's still hardcoded this at least differentiates between the
different Mono versions. Normally on Windows when people have both
versions installed the 64 bit version is installed in "C:\Program Files"
and the 32bit in "C:\Program Files (x86)".