### PR TITLE
Linking on windows

### DIFF
--- a/mono/config.py
+++ b/mono/config.py
@@ -1,6 +1,17 @@
 
-from subprocess import call
-from SCons.Script import File
+import os
+from SCons.Script import Environment
+
+
+def get_program_files_32():
+    if os.getenv('PROGRAMFILES(X86)'):
+        return os.getenv('PROGRAMFILES(X86)')
+    else:
+        return os.getenv('PROGRAMFILES')
+
+
+def get_program_files_64():
+    return os.getenv('PROGRAMW6432')
 
 
 def can_build(platform):
@@ -11,14 +22,26 @@ def configure(env):
     env.use_ptrcall = True
 
     if env['platform'] == 'windows':
-        if env['bits'] == '64':
-            env.Append(LIBPATH = 'C:\\Program Files\\Mono\\lib\\')
-            env.Append(CPPPATH = 'C:\\Program Files\\Mono\\include\\mono-2.0\\')
+        if env['bits'] == '32':
+            if os.getenv('MONO32_PREFIX'):
+                mono_path = os.getenv('MONO32_PREFIX')
+            else:
+                mono_path = os.path.join(get_program_files_32(), 'Mono')
         else:
-            env.Append(LIBPATH = 'C:\\Program Files (x86)\\Mono\\lib\\')
-            env.Append(CPPPATH = 'C:\\Program Files (x86)\\Mono\\include\\mono-2.0\\')
+            if os.getenv('MONO64_PREFIX'):
+                mono_path = os.getenv('MONO64_PREFIX')
+            else:
+                mono_path = os.path.join(get_program_files_64(), 'Mono')
 
-        env.Append(LINKFLAGS = [ 'monosgen-2.0.lib' ])
+        env.Append(LIBPATH = os.path.join(mono_path, 'lib'))
+        env.Append(CPPPATH = os.path.join(mono_path, 'include', 'mono-2.0'))
+
+        mono_lib = 'monosgen-2.0'
+
+        if os.getenv("VCINSTALLDIR"):
+            env.Append(LINKFLAGS = mono_lib + Environment()['LIBSUFFIX'])
+        else:
+            env.Append(LIBS = mono_lib )
     else:
         env.ParseConfig('pkg-config mono-2 --cflags --libs')
         env.Append(LINKFLAGS = '-rdynamic')


### PR DESCRIPTION
- The following environment variables have priority over hard-coded paths: `MONO32_PREFIX`, `MONO64_PREFIX`
- Make sure to get the correct ProgramFiles path on different windows architectures.
- Support linking with MinGW.
