### PR TITLE
Fixes Mathf.lerp typo, Issue #21

### DIFF
--- a/mono/glue/cs_files/Mathf.cs
+++ b/mono/glue/cs_files/Mathf.cs
@@ -134,9 +134,9 @@ namespace GodotEngine
             }
         }
 
-        public static float lerp(float from, float to, float weigth)
+        public static float lerp(float from, float to, float weight)
         {
-            return from + (to - from) * clamp(weigth, 0f, 1f);
+            return from + (to - from) * clamp(weight, 0f, 1f);
         }
 
         public static float log(float s)


### PR DESCRIPTION
Fixes the typo described by Issue #21 by changing weigth to weight.