### PR TITLE
Replaces references to global_config with project_settings

### DIFF
--- a/mono/csharp_script.cpp
+++ b/mono/csharp_script.cpp
@@ -28,7 +28,7 @@
 
 #include <mono/metadata/threads.h>
 
-#include "global_config.h"
+#include "project_settings.h"
 #include "os/file_access.h"
 #include "os/os.h"
 #include "os/thread.h"
@@ -516,9 +516,9 @@ Error CSharpLanguage::open_in_external_editor(const Ref<Script> &p_script, int p
 	switch (editor) {
 		case EDITOR_CODE: {
 			List<String> args;
-			args.push_back(GlobalConfig::get_singleton()->get_resource_path());
+			args.push_back(ProjectSettings::get_singleton()->get_resource_path());
 
-			String script_path = GlobalConfig::get_singleton()->globalize_path(p_script->get_path());
+			String script_path = ProjectSettings::get_singleton()->globalize_path(p_script->get_path());
 
 			if (p_line >= 0) {
 				args.push_back("-g");

--- a/mono/editor/bindings_generator.cpp
+++ b/mono/editor/bindings_generator.cpp
@@ -27,7 +27,7 @@
 
 #ifdef DEBUG_METHODS_ENABLED
 
-#include "global_config.h"
+#include "project_settings.h"
 #include "io/compression.h"
 #include "os/dir_access.h"
 #include "os/file_access.h"
@@ -934,7 +934,7 @@ Error BindingsGenerator::generate_glue(String p_output_dir) {
 
 			cpp_file.push_back("Object* ");
 			cpp_file.push_back(singleton_icall);
-			cpp_file.push_back("() " OPEN_BLOCK "\treturn GlobalConfig::get_singleton()->get_singleton_object(\"");
+			cpp_file.push_back("() " OPEN_BLOCK "\treturn ProjectSettings::get_singleton()->get_singleton_object(\"");
 			cpp_file.push_back(itype.proxy_name);
 			cpp_file.push_back("\");\n" CLOSE_BLOCK "\n");
 		}
@@ -1040,7 +1040,7 @@ void BindingsGenerator::generate_obj_types() {
 		TypeInterface itype = TypeInterface::create_object_type(type_cname);
 
 		itype.base_name = ClassDB::get_parent_class(type_cname);
-		itype.is_singleton = GlobalConfig::get_singleton()->has_singleton(itype.proxy_name);
+		itype.is_singleton = ProjectSettings::get_singleton()->has_singleton(itype.proxy_name);
 		itype.is_instantiable = ClassDB::can_instance(type_cname) && !itype.is_singleton;
 		itype.is_creatable = itype.is_instantiable && is_creatable_type(itype.name);
 		itype.is_reference = ClassDB::is_parent_class(type_cname, refclass_name);

--- a/mono/editor/csharp_project.cpp
+++ b/mono/editor/csharp_project.cpp
@@ -25,7 +25,7 @@
 /**********************************************************************************/
 #include "csharp_project.h"
 
-#include "global_config.h"
+#include "project_settings.h"
 #include "os/dir_access.h"
 #include "os/file_access.h"
 
@@ -213,7 +213,7 @@ void CSharpProject::set_target_framework(TargetFramework p_target_framework) {
 
 bool CSharpProject::has_file(const String &p_path) {
 	String path = p_path.substr(6, p_path.length()); // remove res://
-	String abs_path = GlobalConfig::get_singleton()->globalize_path(p_path);
+	String abs_path = ProjectSettings::get_singleton()->globalize_path(p_path);
 
 	XMLElement *proj = data->doc->FirstChildElement("Project");
 	ERR_FAIL_COND_V(!proj, false);
@@ -276,7 +276,7 @@ void CSharpProject::add_file(const String &p_path) {
 
 void CSharpProject::remove_file(const String &p_path) {
 	String path = p_path.substr(6, p_path.length()); // remove res://
-	String abs_path = GlobalConfig::get_singleton()->globalize_path(p_path);
+	String abs_path = ProjectSettings::get_singleton()->globalize_path(p_path);
 
 	XMLElement *proj = data->doc->FirstChildElement("Project");
 	ERR_FAIL_COND(!proj);
@@ -308,7 +308,7 @@ void CSharpProject::remove_file(const String &p_path) {
 }
 
 void CSharpProject::get_files(const String &p_include_pattern, List<String> *r_paths) {
-	String abs_incl_patter = GlobalConfig::get_singleton()->globalize_path(p_include_pattern);
+	String abs_incl_patter = ProjectSettings::get_singleton()->globalize_path(p_include_pattern);
 
 	XMLElement *proj = data->doc->FirstChildElement("Project");
 	ERR_FAIL_COND(!proj);

--- a/mono/glue/cs_files/Mathf.cs
+++ b/mono/glue/cs_files/Mathf.cs
@@ -134,9 +134,9 @@ namespace GodotEngine
             }
         }
 
-        public static float lerp(float from, float to, float weigth)
+        public static float lerp(float from, float to, float weight)
         {
-            return from + (to - from) * clamp(weigth, 0f, 1f);
+            return from + (to - from) * clamp(weight, 0f, 1f);
         }
 
         public static float log(float s)

--- a/mono/glue/mono_glue.cpp
+++ b/mono/glue/mono_glue.cpp
@@ -901,7 +901,7 @@ MonoObject* godot_icall_0_91(MethodBind* method, Object* ptr) {
 }
 
 Object* godot_icall_AudioServer_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("AudioServer");
+	return ProjectSettings::get_singleton()->get_singleton_object("AudioServer");
 }
 
 void godot_icall_1_92(MethodBind* method, Object* ptr, MonoArray* arg1) {
@@ -2317,7 +2317,7 @@ MonoObject* godot_icall_1_212(MethodBind* method, Object* ptr, MonoString* arg1)
 }
 
 Object* godot_icall_GlobalConfig_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("GlobalConfig");
+	return ProjectSettings::get_singleton()->get_singleton_object("GlobalConfig");
 }
 
 void godot_icall_2_213(MethodBind* method, Object* ptr, real_t arg1, real_t* arg2) {
@@ -2642,7 +2642,7 @@ int godot_icall_2_240(MethodBind* method, Object* ptr, MonoString* arg1, int arg
 }
 
 Object* godot_icall_IP_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("IP");
+	return ProjectSettings::get_singleton()->get_singleton_object("IP");
 }
 
 void godot_icall_4_241(MethodBind* method, Object* ptr, int arg1, int arg2, bool arg3, int arg4) {
@@ -2771,7 +2771,7 @@ void godot_icall_2_255(MethodBind* method, Object* ptr, Object* arg1, real_t* ar
 }
 
 Object* godot_icall_Input_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("Input");
+	return ProjectSettings::get_singleton()->get_singleton_object("Input");
 }
 
 bool godot_icall_1_256(MethodBind* method, Object* ptr, Object* arg1) {
@@ -2868,7 +2868,7 @@ bool godot_icall_2_260(MethodBind* method, Object* ptr, Object* arg1, MonoString
 }
 
 Object* godot_icall_InputMap_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("InputMap");
+	return ProjectSettings::get_singleton()->get_singleton_object("InputMap");
 }
 
 MonoObject* godot_icall_1_261(MethodBind* method, Object* ptr, bool arg1) {
@@ -3848,7 +3848,7 @@ Object* godot_icall_PathFollow2D_Ctor(MonoObject* obj) {
 }
 
 Object* godot_icall_Performance_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("Performance");
+	return ProjectSettings::get_singleton()->get_singleton_object("Performance");
 }
 
 RID* godot_icall_1_337(MethodBind* method, Object* ptr, int arg1) {
@@ -4141,7 +4141,7 @@ RID* godot_icall_4_373(MethodBind* method, Object* ptr, real_t* arg1, real_t* ar
 }
 
 Object* godot_icall_Physics2DServer_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("Physics2DServer");
+	return ProjectSettings::get_singleton()->get_singleton_object("Physics2DServer");
 }
 
 void godot_icall_1_374(MethodBind* method, Object* ptr, MonoArray* arg1) {
@@ -4334,7 +4334,7 @@ bool godot_icall_3_395(MethodBind* method, Object* ptr, RID* arg1, int arg2, int
 }
 
 Object* godot_icall_PhysicsServer_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("PhysicsServer");
+	return ProjectSettings::get_singleton()->get_singleton_object("PhysicsServer");
 }
 
 Object* godot_icall_PhysicsShapeQueryParameters_Ctor(MonoObject* obj) {
@@ -5444,7 +5444,7 @@ Object* godot_icall_Translation_Ctor(MonoObject* obj) {
 }
 
 Object* godot_icall_TranslationServer_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("TranslationServer");
+	return ProjectSettings::get_singleton()->get_singleton_object("TranslationServer");
 }
 
 MonoObject* godot_icall_1_470(MethodBind* method, Object* ptr, Object* arg1) {
@@ -6118,7 +6118,7 @@ RID* godot_icall_2_505(MethodBind* method, Object* ptr, Object* arg1, int arg2) 
 }
 
 Object* godot_icall_VisualServer_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("VisualServer");
+	return ProjectSettings::get_singleton()->get_singleton_object("VisualServer");
 }
 
 Object* godot_icall_WeakRef_Ctor(MonoObject* obj) {
@@ -6228,7 +6228,7 @@ MonoArray* godot_icall_2_512(MethodBind* method, Object* ptr, MonoString* arg1, 
 }
 
 Object* godot_icall__ClassDB_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("ClassDB");
+	return ProjectSettings::get_singleton()->get_singleton_object("ClassDB");
 }
 
 int godot_icall_2_513(MethodBind* method, Object* ptr, bool arg1, bool arg2) {
@@ -6263,7 +6263,7 @@ MonoObject* godot_icall_0_515(MethodBind* method, Object* ptr) {
 }
 
 Object* godot_icall__Engine_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("Engine");
+	return ProjectSettings::get_singleton()->get_singleton_object("Engine");
 }
 
 int godot_icall_3_516(MethodBind* method, Object* ptr, MonoString* arg1, int arg2, MonoArray* arg3) {
@@ -6477,11 +6477,11 @@ MonoObject* godot_icall_1_535(MethodBind* method, Object* ptr, MonoArray* arg1) 
 }
 
 Object* godot_icall__Geometry_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("Geometry");
+	return ProjectSettings::get_singleton()->get_singleton_object("Geometry");
 }
 
 Object* godot_icall__GodotSharp_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("GodotSharp");
+	return ProjectSettings::get_singleton()->get_singleton_object("GodotSharp");
 }
 
 MonoString* godot_icall_1_536(MethodBind* method, Object* ptr, MonoArray* arg1) {
@@ -6503,7 +6503,7 @@ MonoArray* godot_icall_1_537(MethodBind* method, Object* ptr, MonoString* arg1) 
 }
 
 Object* godot_icall__Marshalls_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("Marshalls");
+	return ProjectSettings::get_singleton()->get_singleton_object("Marshalls");
 }
 
 Object* godot_icall_Mutex_Ctor(MonoObject* obj) {
@@ -6544,7 +6544,7 @@ int godot_icall_4_540(MethodBind* method, Object* ptr, MonoString* arg1, real_t 
 }
 
 Object* godot_icall__OS_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("OS");
+	return ProjectSettings::get_singleton()->get_singleton_object("OS");
 }
 
 MonoObject* godot_icall_2_541(MethodBind* method, Object* ptr, MonoString* arg1, MonoString* arg2) {
@@ -6568,7 +6568,7 @@ MonoObject* godot_icall_3_542(MethodBind* method, Object* ptr, MonoString* arg1,
 }
 
 Object* godot_icall__ResourceLoader_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("ResourceLoader");
+	return ProjectSettings::get_singleton()->get_singleton_object("ResourceLoader");
 }
 
 int godot_icall_3_543(MethodBind* method, Object* ptr, MonoString* arg1, Object* arg2, int arg3) {
@@ -6589,7 +6589,7 @@ MonoArray* godot_icall_1_544(MethodBind* method, Object* ptr, Object* arg1) {
 }
 
 Object* godot_icall__ResourceSaver_get_singleton() {
-	return GlobalConfig::get_singleton()->get_singleton_object("ResourceSaver");
+	return ProjectSettings::get_singleton()->get_singleton_object("ResourceSaver");
 }
 
 Object* godot_icall_Semaphore_Ctor(MonoObject* obj) {

--- a/mono/mono_wrapper/gd_mono.cpp
+++ b/mono/mono_wrapper/gd_mono.cpp
@@ -29,7 +29,7 @@
 #include <mono/metadata/mono-debug.h>
 #include <mono/utils/mono-logger.h>
 
-#include "global_config.h"
+#include "project_settings.h"
 #include "os/file_access.h"
 #include "os/os.h"
 #include "os/thread.h"
@@ -97,7 +97,7 @@ bool GDMono::_load_script_assemblies() {
 
 	String assemblies_path = get_assemblies_path();
 
-	String project_assembly_name = GlobalConfig::get_singleton()->get("application/name");
+	String project_assembly_name = ProjectSettings::get_singleton()->get("application/name");
 	String project_assembly_path = path_join(assemblies_path, project_assembly_name + ".dll");
 
 	if (FileAccess::exists(project_assembly_path)) {

--- a/mono/mono_wrapper/gd_mono_utils.cpp
+++ b/mono/mono_wrapper/gd_mono_utils.cpp
@@ -25,7 +25,7 @@
 /**********************************************************************************/
 #include "gd_mono_utils.h"
 
-#include "global_config.h"
+#include "project_settings.h"
 #include "os/dir_access.h"
 #include "reference.h"
 
@@ -423,7 +423,7 @@ void expand_wildcard(const String &p_wildcard, List<String> *r_result) {
 		da->change_dir("/");
 		wildcard = wildcard.substr(1, wildcard.length());
 	} else {
-		da->change_dir(GlobalConfig::get_singleton()->globalize_path("res://"));
+		da->change_dir(ProjectSettings::get_singleton()->globalize_path("res://"));
 	}
 
 	_find_wildcard_files(wildcard, da, r_result);

--- a/mono/register_types.cpp
+++ b/mono/register_types.cpp
@@ -44,7 +44,7 @@ void register_mono_types() {
 
 	_godotsharp = memnew(_GodotSharp);
 
-	GlobalConfig::get_singleton()->add_singleton(GlobalConfig::Singleton("GodotSharp", _GodotSharp::get_singleton()));
+	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("GodotSharp", _GodotSharp::get_singleton()));
 
 	script_language_cs = memnew(CSharpLanguage);
 	ScriptServer::register_language(script_language_cs);

--- a/mono/utils/path_utils.cpp
+++ b/mono/utils/path_utils.cpp
@@ -25,7 +25,7 @@
 /**********************************************************************************/
 #include "path_utils.h"
 
-#include "global_config.h"
+#include "project_settings.h"
 #include "os/dir_access.h"
 #include "os/file_access.h"
 #include "os/os.h"


### PR DESCRIPTION
`global_config.cpp` was depreciated, instead the methods used are in `project_settings.cpp` . This would cause the modules to not compile. Includes Issue21Fix because I'm not very good at git yet, sorry.