### PR TITLE
Removed 'lib' as a prefix on Windows because libs aren't prefixed with 'lib' on Windows

### DIFF
--- a/mono/config.py
+++ b/mono/config.py
@@ -52,9 +52,14 @@ def configure(env):
         env.Append(CPPPATH = os.path.join(mono_root, 'include', 'mono-2.0'))
 
         mono_lib_names = [ 'mono-2.0-sgen', 'monosgen-2.0' ]
+
+        if sys.platform == 'win32':
+            prefix = ''
+        else:
+            prefix = 'lib'
         mono_lib_name = find_file_in_dir(
             mono_lib_path, mono_lib_names,
-            'lib', '.lib'
+            prefix, '.lib'
         )
 
         if not mono_lib_name:


### PR DESCRIPTION
There's no such file as 'libmono-2.0-sgen.lib' on Windows, so it was failing to find the file. So, the 'lib' prefix is now not searched for on Windows and instead looks for 'mono-2.0-sgen.lib' which it now finds.